### PR TITLE
update example, upgrade express from version 3 to 4

### DIFF
--- a/examples/login/.gitignore
+++ b/examples/login/.gitignore
@@ -1,0 +1,2 @@
+
+node_modules

--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -1,5 +1,10 @@
 var express = require('express')
   , passport = require('passport')
+  , morgan = require('morgan')
+  , cookieParser = require('cookie-parser')
+  , bodyParser = require('body-parser')
+  , methodOverride = require('method-override')
+  , session = require('express-session')
   , util = require('util')
   , InstagramStrategy = require('passport-instagram').Strategy;
 
@@ -48,24 +53,28 @@ passport.use(new InstagramStrategy({
 
 
 
-var app = express.createServer();
-
+var app = express();
 // configure Express
-app.configure(function() {
+
   app.set('views', __dirname + '/views');
   app.set('view engine', 'ejs');
-  app.use(express.logger());
-  app.use(express.cookieParser());
-  app.use(express.bodyParser());
-  app.use(express.methodOverride());
-  app.use(express.session({ secret: 'keyboard cat' }));
-  // Initialize Passport!  Also use passport.session() middleware, to support
+  app.use(morgan('combined'));
+  app.use(cookieParser());
+  app.use(bodyParser.urlencoded({
+    extended: true
+  }));
+  app.use(bodyParser.json());
+  app.use(methodOverride());
+  app.use(session({
+    saveUninitialized: true,
+    resave: true,
+    secret: 'secret'
+  }));  // Initialize Passport!  Also use passport.session() middleware, to support
   // persistent login sessions (recommended).
   app.use(passport.initialize());
   app.use(passport.session());
-  app.use(app.router);
   app.use(express.static(__dirname + '/public'));
-});
+
 
 
 app.get('/', function(req, res){
@@ -108,8 +117,15 @@ app.get('/logout', function(req, res){
   res.redirect('/');
 });
 
-app.listen(3000);
+var port = 3000;
 
+app.listen(port, function(error) {
+  if (error) {
+    console.error(error)
+  } else {
+    console.info("==> 🌎  Listening on port %s. Open up http://localhost:%s/ in your browser.", port, port)
+  }
+})
 
 // Simple route middleware to ensure user is authenticated.
 //   Use this route middleware on any resource that needs to be protected.  If

--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -2,9 +2,14 @@
   "name": "passport-instagram-examples-login",
   "version": "0.0.0",
   "dependencies": {
-    "express": ">= 0.0.0",
-    "ejs": ">= 0.0.0",
-    "passport": ">= 0.0.0",
-    "passport-instagram": ">= 0.0.0"
+    "body-parser": "^1.14.2",
+    "cookie-parser": "^1.4.1",
+    "ejs": "^2.3.4",
+    "express": "^4.13.3",
+    "express-session": "^1.13.0",
+    "method-override": "^2.3.5",
+    "morgan": "^1.6.1",
+    "passport": "^0.3.2",
+    "passport-instagram": "^1.0.0"
   }
 }


### PR DESCRIPTION
The old example uses Express.js 3.x.

Express.js 3.x is deprecated.

Update to Express.js 4.x.

Thanks,
Kevin.
